### PR TITLE
Fix log crash when backing on scrolling

### DIFF
--- a/app/src/main/java/io/nekohasekai/sagernet/ui/LogcatFragment.kt
+++ b/app/src/main/java/io/nekohasekai/sagernet/ui/LogcatFragment.kt
@@ -342,6 +342,7 @@ class LogcatFragment : ToolbarFragment(R.layout.layout_logcat),
     }
 
     override fun onScroll(offset: Int) {
+        if (context == null) return
         val activity = requireActivity() as MainActivity
         val topRow = binding.terminalView.topRow
         if (offset < 0) {


### PR DESCRIPTION
```
D/AndroidRuntime: Shutting down VM
E/AndroidRuntime: FATAL EXCEPTION: main
E/AndroidRuntime: Process: com.github.dyhkwong.sagernet, PID: 23603
E/AndroidRuntime: java.lang.IllegalStateException: Fragment LogcatFragment{1b4683a} (cc5d3e79-00b1-4b39-b80d-d7835f9ad334) not attached to an activity.
E/AndroidRuntime:       at androidx.fragment.app.Fragment.requireActivity(SourceFile:18)
E/AndroidRuntime:       at io.nekohasekai.sagernet.ui.LogcatFragment.onScroll(SourceFile:1)
E/AndroidRuntime:       at com.termux.view.TerminalView.doScroll(SourceFile:106)
E/AndroidRuntime:       at com.termux.view.TerminalView$1$onFling$1.run(SourceFile:192)
E/AndroidRuntime:       at android.os.Handler.handleCallback(Handler.java:938)
E/AndroidRuntime:       at android.os.Handler.dispatchMessage(Handler.java:99)
E/AndroidRuntime:       at android.os.Looper.loopOnce(Looper.java:210)
E/AndroidRuntime:       at android.os.Looper.loop(Looper.java:299)
E/AndroidRuntime:       at android.app.ActivityThread.main(ActivityThread.java:8292)
E/AndroidRuntime:       at java.lang.reflect.Method.invoke(Native Method)
E/AndroidRuntime:       at com.android.internal.os.RuntimeInit$MethodAndArgsCaller.run(RuntimeInit.java:556)
E/AndroidRuntime:       at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:1045)
```