### PR TITLE
Replace `app.getString()` with `Context.getString()``

### DIFF
--- a/app/src/main/java/io/nekohasekai/sagernet/bg/BaseService.kt
+++ b/app/src/main/java/io/nekohasekai/sagernet/bg/BaseService.kt
@@ -282,12 +282,13 @@ class BaseService {
                 Logs.w(e)
                 var msg = e.readableMessage
                 val msgL = msg.lowercase()
+                val context = data!!.proxy!!.service as Context
                 when {
                     msgL.contains("timeout") || msg.contains("deadline") -> {
-                        msg = app.getString(R.string.connection_test_timeout)
+                        msg = context.getString(R.string.connection_test_timeout)
                     }
                     msg.contains("refused") || msgL.contains("closed pipe") -> {
-                        msg = app.getString(R.string.connection_test_refused)
+                        msg = context.getString(R.string.connection_test_refused)
                     }
                 }
                 error(msg)

--- a/app/src/main/java/io/nekohasekai/sagernet/ui/RouteSettingsActivity.kt
+++ b/app/src/main/java/io/nekohasekai/sagernet/ui/RouteSettingsActivity.kt
@@ -56,7 +56,6 @@ import io.nekohasekai.sagernet.database.RuleEntity
 import io.nekohasekai.sagernet.database.SagerDatabase
 import io.nekohasekai.sagernet.database.preference.OnPreferenceDataStoreChangeListener
 import io.nekohasekai.sagernet.ktx.Logs
-import io.nekohasekai.sagernet.ktx.app
 import io.nekohasekai.sagernet.ktx.onMainDispatcher
 import io.nekohasekai.sagernet.ktx.runOnDefaultDispatcher
 import io.nekohasekai.sagernet.ktx.runOnMainDispatcher
@@ -83,7 +82,7 @@ class RouteSettingsActivity(
         RuleEntity().apply {
             if (!packageName.isNullOrEmpty()) {
                 packages = listOf(packageName)
-                name = app.getString(R.string.route_for, PackageCache.loadLabel(packageName))
+                name = getString(R.string.route_for, PackageCache.loadLabel(packageName))
             }
         }.init()
     }
@@ -240,15 +239,15 @@ class RouteSettingsActivity(
 
         fun updateNetwork(newValues: Set<String> = networkType.values) {
             networkType.summary = if (newValues.isEmpty()) {
-                app.getString(androidx.preference.R.string.not_set)
+                getString(androidx.preference.R.string.not_set)
             } else {
                 val types = mutableListOf<String>()
-                if (newValues.contains("data")) types.add(app.getString(R.string.network_data))
-                if (newValues.contains("wifi")) types.add(app.getString(R.string.network_wifi))
-                if (newValues.contains("bluetooth")) types.add(app.getString(R.string.network_bt))
-                if (newValues.contains("ethernet")) types.add(app.getString(R.string.network_eth))
-                if (newValues.contains("usb")) types.add(app.getString(R.string.network_usb))
-                if (newValues.contains("satellite")) types.add(app.getString(R.string.network_satellite))
+                if (newValues.contains("data")) types.add(getString(R.string.network_data))
+                if (newValues.contains("wifi")) types.add(getString(R.string.network_wifi))
+                if (newValues.contains("bluetooth")) types.add(getString(R.string.network_bt))
+                if (newValues.contains("ethernet")) types.add(getString(R.string.network_eth))
+                if (newValues.contains("usb")) types.add(getString(R.string.network_usb))
+                if (newValues.contains("satellite")) types.add(getString(R.string.network_satellite))
                 types.joinToString("\n")
             }
             ssid.isVisible = newValues.contains("wifi")

--- a/app/src/main/java/io/nekohasekai/sagernet/widget/LinkOrContentPreference.kt
+++ b/app/src/main/java/io/nekohasekai/sagernet/widget/LinkOrContentPreference.kt
@@ -26,7 +26,6 @@ import androidx.core.widget.addTextChangedListener
 import com.google.android.material.textfield.TextInputLayout
 import com.takisoft.preferencex.EditTextPreference
 import io.nekohasekai.sagernet.R
-import io.nekohasekai.sagernet.ktx.app
 import io.nekohasekai.sagernet.ktx.readableMessage
 
 class LinkOrContentPreference : EditTextPreference {
@@ -66,7 +65,7 @@ class LinkOrContentPreference : EditTextPreference {
                         linkLayout.isErrorEnabled = false
                         return
                     } else if (uri.scheme == "http") {
-                        linkLayout.error = app.getString(R.string.cleartext_http_warning)
+                        linkLayout.error = context.getString(R.string.cleartext_http_warning)
                         linkLayout.isErrorEnabled = true
                     } else if (uri.scheme != "https") {
                         error("Invalid scheme ${uri.scheme}")

--- a/app/src/main/java/io/nekohasekai/sagernet/widget/LinkPreference.kt
+++ b/app/src/main/java/io/nekohasekai/sagernet/widget/LinkPreference.kt
@@ -26,7 +26,6 @@ import androidx.core.widget.addTextChangedListener
 import com.google.android.material.textfield.TextInputLayout
 import com.takisoft.preferencex.EditTextPreference
 import io.nekohasekai.sagernet.R
-import io.nekohasekai.sagernet.ktx.app
 import io.nekohasekai.sagernet.ktx.readableMessage
 import libcore.Libcore
 
@@ -87,7 +86,7 @@ class LinkPreference : EditTextPreference {
                     if (uri.scheme.isNullOrBlank()) {
                         error("Missing scheme in url")
                     } else if (uri.scheme == "http") {
-                        linkLayout.error = app.getString(R.string.cleartext_http_warning)
+                        linkLayout.error = context.getString(R.string.cleartext_http_warning)
                         linkLayout.isErrorEnabled = true
                     } else if (uri.scheme != "https") {
                         error("Invalid scheme ${uri.scheme}")

--- a/app/src/main/java/io/nekohasekai/sagernet/widget/StatsBar.kt
+++ b/app/src/main/java/io/nekohasekai/sagernet/widget/StatsBar.kt
@@ -88,7 +88,7 @@ class StatsBar @JvmOverloads constructor(
         if ((state == BaseService.State.Connected).also { hideOnScroll = it }) {
             doOnPreDraw {
                 performShow()
-                setStatus(app.getText(R.string.vpn_connected))
+                setStatus(context.getText(R.string.vpn_connected))
             }
         } else {
             doOnPreDraw {
@@ -124,14 +124,14 @@ class StatsBar @JvmOverloads constructor(
     fun testConnection() {
         val activity = context as MainActivity
         isEnabled = false
-        setStatus(app.getText(R.string.connection_test_testing))
+        setStatus(context.getText(R.string.connection_test_testing))
         runOnDefaultDispatcher {
             try {
                 val elapsed = activity.urlTest()
                 onMainDispatcher {
                     isEnabled = true
                     setStatus(
-                        app.getString(
+                        activity.getString(
                             if (DataStore.connectionTestURL.startsWith("https://")) {
                                 R.string.connection_test_available
                             } else {
@@ -145,10 +145,10 @@ class StatsBar @JvmOverloads constructor(
                 Logs.w(e)
                 onMainDispatcher {
                     isEnabled = true
-                    setStatus(app.getText(R.string.connection_test_testing))
+                    setStatus(context.getText(R.string.connection_test_testing))
 
                     activity.snackbar(
-                        app.getString(
+                        activity.getString(
                             R.string.connection_test_error, e.readableMessage
                         )
                     ).show()


### PR DESCRIPTION
![photo_2025-07-11_21-55-35](https://github.com/user-attachments/assets/e8b7466b-5914-4911-b3f2-12d80dd522de)

There are still many instances of 'app.getString()' that need to be replaced. Furthermore, we should reconsider the implementation of the in-app language picker.