### PR TITLE
Fix hardcoded VLESS REALITY fingerprint

### DIFF
--- a/app/src/main/java/io/nekohasekai/sagernet/fmt/v2ray/V2RayFmt.kt
+++ b/app/src/main/java/io/nekohasekai/sagernet/fmt/v2ray/V2RayFmt.kt
@@ -245,6 +245,9 @@ fun parseV2Ray(link: String): StandardV2RayBean {
             url.queryParameterNotBlank("pqv")?.let {
                 bean.realityMldsa65Verify = it
             }
+            url.queryParameterNotBlank("fp")?.let {
+                bean.realityFingerprint = it
+            }
             if (bean is VLESSBean) {
                 url.queryParameterNotBlank("flow")?.let {
                     when (it) {
@@ -890,7 +893,7 @@ fun StandardV2RayBean.toUri(): String? {
             if (realityMldsa65Verify.isNotEmpty()) {
                 builder.addQueryParameter("pqv", realityMldsa65Verify)
             }
-            builder.addQueryParameter("fp", "chrome") // "若使用 REALITY，此项不可省略。"
+            builder.addQueryParameter("fp", realityFingerprint.ifEmpty { "chrome" })
             if (this is VLESSBean && flow.isNotEmpty()) {
                 builder.addQueryParameter("flow", flow.removeSuffix("-udp443"))
             }

--- a/app/src/main/java/io/nekohasekai/sagernet/group/ClashYAMLParser.kt
+++ b/app/src/main/java/io/nekohasekai/sagernet/group/ClashYAMLParser.kt
@@ -343,6 +343,9 @@ fun parseClashProxy(proxy: Map<String, Any?>): List<AbstractBean> {
                 bean.realityPublicKey = it.getString("public-key")?.ifEmpty { return listOf() }
                 bean.realityShortId = it.getString("short-id")
             }
+            proxy.getString("client-fingerprint")?.also {
+                bean.realityFingerprint = it
+            }
 
             if (bean.type == "tcp" && bean.headerType != null && bean.headerType == "http") {
                 proxy.getObject("http-opts")?.also {

--- a/app/src/main/java/io/nekohasekai/sagernet/group/SingBoxJSONParser.kt
+++ b/app/src/main/java/io/nekohasekai/sagernet/group/SingBoxJSONParser.kt
@@ -223,6 +223,9 @@ fun parseSingBoxOutbound(outbound: JsonObject): List<AbstractBean> {
                                         }
                                     }
                                 }
+                                tls.getString("utls")?.also {
+                                    v2rayBean.realityFingerprint = it
+                                }
                                 if (v2rayBean is VLESSBean || v2rayBean is TrojanBean) {
                                     // Only parse ECH for shit VLESS or Trojan free nodes
                                     tls.getObject("ech")?.also { ech ->
@@ -771,6 +774,9 @@ fun parseSingBoxOutbound(outbound: JsonObject): List<AbstractBean> {
                                         }
                                     }
                                 }
+                            }
+                            tls.getString("utls")?.also {
+                                realityFingerprint = it
                             }
                             /*tls.getObject("ech")?.also { ech ->
                                 ech.getBoolean("enabled")?.also { enabled ->

--- a/app/src/main/java/io/nekohasekai/sagernet/group/V2RayJSONParser.kt
+++ b/app/src/main/java/io/nekohasekai/sagernet/group/V2RayJSONParser.kt
@@ -196,6 +196,9 @@ fun parseV2RayOutbound(outbound: JsonObject): List<AbstractBean> {
                                 realitySettings.getString("mldsa65Verify")?.also {
                                     v2rayBean.realityMldsa65Verify = it
                                 }
+                                realitySettings.getString("fingerprint")?.also {
+                                    v2rayBean.realityFingerprint = it
+                                }
                             }
                         }
                     }


### PR DESCRIPTION
Hello!
Russia has recently started blocking certain Reality fingerprints. While testing, I noticed that the app seems to ignore the `fp` parameter passed in the URL, which I suspect is unintended behavior.
Fixing this would let users override the fingerprint via the URL, so VLESS connections could keep working by switching to a non-blocked `fp`.
