### PR TITLE
Optimize JSON preprocessing

### DIFF
--- a/app/src/main/java/io/nekohasekai/sagernet/ktx/Json.kt
+++ b/app/src/main/java/io/nekohasekai/sagernet/ktx/Json.kt
@@ -205,8 +205,8 @@ fun stripJson(jsonString: String, stripTrailingCommas: Boolean = false): String 
     var isInsideString = false
     var isInsideComment = notInsideComment
     var offset = 0
-    var buffer = ""
-    var result = ""
+    val buffer = StringBuilder()
+    val result = StringBuilder(jsonString.length)
     var commaIndex = -1
 
     var index = 0
@@ -229,7 +229,7 @@ fun stripJson(jsonString: String, stripTrailingCommas: Boolean = false): String 
         when {
             isInsideComment == notInsideComment && currentCharacter == '/' && nextCharacter == '/' -> {
                 // Enter single-line comment
-                buffer += jsonString.substring(offset, index)
+                buffer.append(jsonString, offset, index)
                 offset = index
                 isInsideComment = singleComment
                 index++
@@ -247,7 +247,7 @@ fun stripJson(jsonString: String, stripTrailingCommas: Boolean = false): String 
             }
             isInsideComment == notInsideComment && currentCharacter == '/' && nextCharacter == '*' -> {
                 // Enter multiline comment
-                buffer += jsonString.substring(offset, index)
+                buffer.append(jsonString, offset, index)
                 offset = index
                 isInsideComment = multiComment
                 index++
@@ -262,21 +262,21 @@ fun stripJson(jsonString: String, stripTrailingCommas: Boolean = false): String 
                 if (commaIndex != -1) {
                     if (currentCharacter == '}' || currentCharacter == ']') {
                         // Strip trailing comma
-                        buffer += jsonString.substring(offset, index)
-                        result += buffer.substring(1)
-                        buffer = ""
+                        buffer.append(jsonString, offset, index)
+                        result.append(buffer, 1, buffer.length)
+                        buffer.setLength(0)
                         offset = index
                         commaIndex = -1
                     } else if (currentCharacter != ' ' && currentCharacter != '\t' && currentCharacter != '\r' && currentCharacter != '\n') {
                         // Hit non-whitespace following a comma; comma is not trailing
-                        buffer += jsonString.substring(offset, index)
+                        buffer.append(jsonString, offset, index)
                         offset = index
                         commaIndex = -1
                     }
                 } else if (currentCharacter == ',') {
                     // Flush buffer prior to this point, and save new comma index
-                    result += buffer + jsonString.substring(offset, index)
-                    buffer = ""
+                    result.append(buffer).append(jsonString, offset, index)
+                    buffer.setLength(0)
                     offset = index
                     commaIndex = index
                 }
@@ -284,10 +284,9 @@ fun stripJson(jsonString: String, stripTrailingCommas: Boolean = false): String 
         }
         index++
     }
-    val end = if (isInsideComment > notInsideComment) {
-        ""
-    } else {
-        jsonString.substring(offset)
+    result.append(buffer)
+    if (isInsideComment == notInsideComment) {
+        result.append(jsonString, offset, jsonString.length)
     }
-    return result + buffer + end
+    return result.toString()
 }


### PR DESCRIPTION
`stripJson` used repeated immutable string concatenation while processing commas. For large JSON subscriptions, this caused quadratic runtime, excessive allocations, and very long import times.

Fix: use `StringBuilder`, making preprocessing linear while preserving same behavior.

Before:

https://github.com/user-attachments/assets/cd824b80-e543-40ca-86cf-a8372aaf8abc

After: 

https://github.com/user-attachments/assets/aaa062b5-1013-4978-97a0-3b352d1ee138

