### PR TITLE
Accept random mode in VLESS encryption JSON parsing

### DIFF
--- a/app/src/main/java/io/nekohasekai/sagernet/group/V2RayJSONParser.kt
+++ b/app/src/main/java/io/nekohasekai/sagernet/group/V2RayJSONParser.kt
@@ -769,7 +769,7 @@ fun parseV2RayOutbound(outbound: JsonObject): List<AbstractBean> {
                                 else -> {
                                     val parts = encryption.split(".")
                                     if (parts.size < 4 || parts[0] != "mlkem768x25519plus"
-                                        || !(parts[1] == "native" || parts[1] == "xorpub" || parts[1] != "random")
+                                        || !(parts[1] == "native" || parts[1] == "xorpub" || parts[1] == "random")
                                         || !(parts[2] == "1rtt" || parts[2] == "0rtt")) {
                                         error("unsupported vless encryption")
                                     }
@@ -806,7 +806,7 @@ fun parseV2RayOutbound(outbound: JsonObject): List<AbstractBean> {
                                     else -> {
                                         val parts = encryption.split(".")
                                         if (parts.size < 4 || parts[0] != "mlkem768x25519plus"
-                                            || !(parts[1] == "native" || parts[1] == "xorpub" || parts[1] != "random")
+                                            || !(parts[1] == "native" || parts[1] == "xorpub" || parts[1] == "random")
                                             || !(parts[2] == "1rtt" || parts[2] == "0rtt")) {
                                             error("unsupported vless encryption")
                                         }


### PR DESCRIPTION
parseV2RayOutbound rejects mlkem768x25519plus.random.* encryption strings.

The last operand of the allowed-mode OR chain is parts[1] != "random" instead of == "random", so the condition reduces to "throw if the mode is random": for native and xorpub the third operand is true regardless, and for random all three are false. 
The same check in ClashYAMLParser.kt and both call sites in V2RayFmt.kt uses == "random". 

Both occurrences in V2RayJSONParser.kt are fixed.